### PR TITLE
Prepare project for PyPI release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/mmprotest/raglite-sqlite/actions/workflows/ci.yml/badge.svg)](https://github.com/mmprotest/raglite-sqlite/actions/workflows/ci.yml)
 ![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Python: 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)
-![PyPI: TODO](https://img.shields.io/badge/PyPI-TODO-lightgrey.svg)
+[![PyPI](https://img.shields.io/pypi/v/raglite.svg)](https://pypi.org/project/raglite/)
 
 Local-first retrieval augmented generation toolkit built on SQLite. Raglite bundles
 ingestion, chunking, hybrid BM25/vector search, Typer CLI workflows, and a FastAPI
@@ -13,7 +13,7 @@ microservice. Everything runs on CPU and stores state in a single SQLite databas
 
 ```bash
 python -m venv .venv && source .venv/bin/activate
-pip install -e .[server]
+pip install "raglite[server]"
 raglite init-db --db demo.db
 raglite ingest --db demo.db --path demo/mini_corpus
 raglite query --db demo.db --text "quick start guide" --k 5 --alpha 0.6
@@ -21,6 +21,28 @@ raglite serve --db demo.db --host 127.0.0.1 --port 8080
 ```
 
 _On Windows use `\.venv\Scripts\activate` for step two._
+
+## Installation
+
+Raglite is published as [`raglite` on PyPI](https://pypi.org/project/raglite/). Install the
+core toolkit with:
+
+```bash
+pip install raglite
+```
+
+To enable the optional FastAPI server, install the `server` extra:
+
+```bash
+pip install "raglite[server]"
+```
+
+Development dependencies (linters, type checkers, packaging utilities) can be installed
+with the `dev` extra:
+
+```bash
+pip install "raglite[dev]"
+```
 
 ## Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,25 @@ readme = "README.md"
 authors = [{ name = "RagLite Contributors" }]
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
+keywords = [
+  "rag",
+  "retrieval-augmented-generation",
+  "sqlite",
+  "search",
+  "llm",
+]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Database",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
 dependencies = [
   "typer>=0.9.0",
   "readability-lxml>=0.8.1",
@@ -31,6 +50,7 @@ rerank = [
   "sentence-transformers>=2.5.0",
 ]
 dev = [
+  "build>=1.2.1",
   "pytest>=8.1.0",
   "pytest-cov>=4.1.0",
   "mypy>=1.8.0",
@@ -38,6 +58,7 @@ dev = [
   "black>=24.4.0",
   "isort>=5.13.2",
   "pre-commit>=3.6.0",
+  "twine>=5.1.1",
 ]
 
 [project.urls]
@@ -49,6 +70,10 @@ raglite = "raglite.cli:app"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+include-package-data = true
 
 [tool.setuptools.package-data]
 raglite = ["schema.sql", "data/eval_set.jsonl", "data/mini_corpus/*"]

--- a/src/raglite/__init__.py
+++ b/src/raglite/__init__.py
@@ -1,7 +1,14 @@
 """raglite - local-first RAG toolkit built on SQLite."""
 
+from importlib import metadata as importlib_metadata
+
 from .api import RagliteAPI, add_tags, index_corpus, init_db, query, stats
 from .config import RagliteConfig
+
+try:
+    __version__ = importlib_metadata.version("raglite")
+except importlib_metadata.PackageNotFoundError:  # pragma: no cover - fallback for dev installs
+    __version__ = "0.0.0"
 
 __all__ = [
     "RagliteAPI",
@@ -11,4 +18,5 @@ __all__ = [
     "init_db",
     "query",
     "stats",
+    "__version__",
 ]


### PR DESCRIPTION
## Summary
- add project classifiers, keywords, and packaging tooling dependencies to pyproject metadata
- expose the installed package version at raglite.__version__ and configure setuptools to ship package data from src/
- document pip installation flows and update the README PyPI badge for the upcoming publication

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0b9c12d988331a66dcc7d0172853a