### PR TITLE
Align project naming with raglite-sqlite distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,4 @@
 - Documented architecture, limitations, and quickstart workflow with new README badges.
 
 ## 0.1.0 - 2024-05-01
-- Initial release of raglite with SQLite-backed RAG pipeline, Typer CLI, FastAPI server, and demo corpus.
+- Initial release of raglite-sqlite with SQLite-backed RAG pipeline, Typer CLI, FastAPI server, and demo corpus.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to raglite
+# Contributing to raglite-sqlite
 
-Thank you for helping improve raglite! The project aims to provide a practical local-first RAG stack powered by SQLite.
+Thank you for helping improve raglite-sqlite! The project aims to provide a practical local-first RAG stack powered by SQLite.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# raglite
+# raglite-sqlite
 
 [![CI](https://github.com/mmprotest/raglite-sqlite/actions/workflows/ci.yml/badge.svg)](https://github.com/mmprotest/raglite-sqlite/actions/workflows/ci.yml)
 ![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Python: 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)
-[![PyPI](https://img.shields.io/pypi/v/raglite.svg)](https://pypi.org/project/raglite/)
+[![PyPI](https://img.shields.io/pypi/v/raglite-sqlite.svg)](https://pypi.org/project/raglite-sqlite/)
 
 Local-first retrieval augmented generation toolkit built on SQLite. Raglite bundles
 ingestion, chunking, hybrid BM25/vector search, Typer CLI workflows, and a FastAPI
@@ -13,7 +13,7 @@ microservice. Everything runs on CPU and stores state in a single SQLite databas
 
 ```bash
 python -m venv .venv && source .venv/bin/activate
-pip install "raglite[server]"
+pip install "raglite-sqlite[server]"
 raglite init-db --db demo.db
 raglite ingest --db demo.db --path demo/mini_corpus
 raglite query --db demo.db --text "quick start guide" --k 5 --alpha 0.6
@@ -24,24 +24,24 @@ _On Windows use `\.venv\Scripts\activate` for step two._
 
 ## Installation
 
-Raglite is published as [`raglite` on PyPI](https://pypi.org/project/raglite/). Install the
+Raglite is published as [`raglite-sqlite` on PyPI](https://pypi.org/project/raglite-sqlite/). Install the
 core toolkit with:
 
 ```bash
-pip install raglite
+pip install raglite-sqlite
 ```
 
 To enable the optional FastAPI server, install the `server` extra:
 
 ```bash
-pip install "raglite[server]"
+pip install "raglite-sqlite[server]"
 ```
 
 Development dependencies (linters, type checkers, packaging utilities) can be installed
 with the `dev` extra:
 
 ```bash
-pip install "raglite[dev]"
+pip install "raglite-sqlite[dev]"
 ```
 
 ## Features
@@ -150,7 +150,7 @@ triggers; see [`src/raglite/schema.sql`](src/raglite/schema.sql) for details.
 > - Best with a single writer; readers work fine with WAL mode. Remember to back up both
 >   `*.db` and `*.db-wal` files.
 > - Increase α to ≥0.6 when keyword precision matters; lower it or enable rerank (with
->   `raglite[rerank]`) for conversational questions.
+>   `raglite-sqlite[rerank]`) for conversational questions.
 > - Raglite is local-first—avoid ingesting secrets or PII. Use `.ragliteignore` patterns or
 >   preprocess files to filter sensitive content.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=64", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "raglite"
+name = "raglite-sqlite"
 version = "0.2.0"
 description = "Local-first RAG toolkit backed by a single SQLite database"
 readme = "README.md"
@@ -88,6 +88,8 @@ known_first_party = ["raglite"]
 
 [tool.ruff]
 line-length = 100
+
+[tool.ruff.lint]
 select = ["E", "F", "I", "B"]
 
 [tool.mypy]

--- a/scripts/eval_small.py
+++ b/scripts/eval_small.py
@@ -170,7 +170,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     if rerank_available():
         metrics.append(evaluate_variant(api, cases, alpha=args.alpha, rerank=True))
     else:
-        print("(Hybrid+Rerank skipped: install raglite[rerank] to enable)")
+        print("(Hybrid+Rerank skipped: install raglite-sqlite[rerank] to enable)")
 
     print_table(metrics)
     if tmp_dir is not None:

--- a/src/raglite/__init__.py
+++ b/src/raglite/__init__.py
@@ -6,7 +6,7 @@ from .api import RagliteAPI, add_tags, index_corpus, init_db, query, stats
 from .config import RagliteConfig
 
 try:
-    __version__ = importlib_metadata.version("raglite")
+    __version__ = importlib_metadata.version("raglite-sqlite")
 except importlib_metadata.PackageNotFoundError:  # pragma: no cover - fallback for dev installs
     __version__ = "0.0.0"
 

--- a/src/raglite/server/app.py
+++ b/src/raglite/server/app.py
@@ -10,7 +10,7 @@ try:
     from fastapi import FastAPI, HTTPException
     from pydantic import BaseModel
 except Exception as exc:  # pragma: no cover - optional dependency
-    raise RuntimeError("Install raglite[server] to use the FastAPI app") from exc
+    raise RuntimeError("Install raglite-sqlite[server] to use the FastAPI app") from exc
 
 from ..api import RagliteAPI
 from ..config import RagliteConfig


### PR DESCRIPTION
## Summary
- rename the project metadata to publish under the raglite-sqlite distribution name
- update documentation and messaging to consistently reference raglite-sqlite extras
- adjust runtime messaging to direct users to install raglite-sqlite optional extras

## Testing
- pytest
- ruff check


------
https://chatgpt.com/codex/tasks/task_e_68e24e1a3e20833187d593a0e4b7e7a3